### PR TITLE
update version to synchronise with artifactory releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.mytaxi.apis</groupId>
     <artifactId>phrase-kotlin-client</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.5-SNAPSHOT</version>
     <name>phrase-api-kotlin</name>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
There's already a version 1.0.4 deployed to artifactory (https://repos.mytaxi.com/artifactory/webapp/#/artifacts/browse/tree/General/internal/com/mytaxi/apis/phrase-kotlin-client/1.0.4/phrase-kotlin-client-1.0.4.jar)

This change is just to bring the version up to 1.0.5-SNAPSHOT which should be the latest.