### PR TITLE
Allow usage of default PhraseAppSyncTaskConfig parameters from Java

### DIFF
--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/task/PhraseAppSyncTask.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/task/PhraseAppSyncTask.kt
@@ -67,7 +67,7 @@ class PhraseAppSyncTask(
     }
 }
 
-data class PhraseAppSyncTaskConfig(
+data class PhraseAppSyncTaskConfig @JvmOverloads constructor(
     val url: String,
     val authKey: String,
     val projectId: String,


### PR DESCRIPTION
- Allow usage of the default PhraseAppSyncTaskConfig constructor parameters from Java.
- Update version to release 1.0.5